### PR TITLE
Only decrypt secrets when doing a deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 script:
   - "mkdocs build --clean -v"
 after_success:
-  if [ "$TRAVIS_BRANCH" == "master" ]; then
+  if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     chmod 0600 .travis/fleetdocsdeploy;
     rsync -C --delete -va -e 'ssh -i .travis/fleetdocsdeploy' ./site/ fleetdocs@torpedo210.anchor.net.au:/home/fleetdocs/public_html/fleet-magento-1/;
   else

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
 addons:
   ssh_known_hosts: torpedo210.anchor.net.au
 before_install:
-  - openssl aes-256-cbc -K $encrypted_d4f50cad59d7_key -iv $encrypted_d4f50cad59d7_iv -in .travis/fleetdocsdeploy.enc -out .travis/fleetdocsdeploy -d
+  if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
+    openssl aes-256-cbc -K $encrypted_d4f50cad59d7_key -iv $encrypted_d4f50cad59d7_iv -in .travis/fleetdocsdeploy.enc -out .travis/fleetdocsdeploy -d;
+  fi;
 install:
   - "pip install -r requirements.txt"
 script:


### PR DESCRIPTION
Our pull request builds are failing because travis doesn't make our
secrets available to potential strangers.  This is a good thing, but
there's no need to decrypt these secrets if we're not intending to
deploy.

Put in some dodgy logic to not attempt decryption on builds we don't
intend to deploy.
