### PR TITLE
docs.anchorfleet.com is now hosted on sail.anchor.net.au

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
 addons:
-  ssh_known_hosts: torpedo210.anchor.net.au
+  ssh_known_hosts: sail.anchor.net.au
 before_install:
   if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     openssl aes-256-cbc -K $encrypted_d4f50cad59d7_key -iv $encrypted_d4f50cad59d7_iv -in .travis/fleetdocsdeploy.enc -out .travis/fleetdocsdeploy -d;
@@ -14,7 +14,7 @@ script:
 after_success:
   if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "master" ]; then
     chmod 0600 .travis/fleetdocsdeploy;
-    rsync -C --delete -va -e 'ssh -i .travis/fleetdocsdeploy' ./site/ fleetdocs@torpedo210.anchor.net.au:/home/fleetdocs/public_html/fleet-magento-1/;
+    rsync -C --delete -va -e 'ssh -i .travis/fleetdocsdeploy' ./site/ fleetdocs@sail.anchor.net.au:/home/fleetdocs/public_html/fleet-magento-1/;
   else
     echo "Not performing a deployment.";
   fi


### PR DESCRIPTION
torpedo210 will soon be decommissioned, Fleet's public docs should now be
published to sail.anchor.net.au instead.
