### PR TITLE
Removing command no longer present (deadlocks)

### DIFF
--- a/docs/troubleshooting/database.md
+++ b/docs/troubleshooting/database.md
@@ -33,39 +33,7 @@ Database deadlocks
 ------------------
 
 Some query patterns can trigger deadlocks in the database. This can
-present as slow page loads or errors. Database deadlocks are recorded
-in the logs:
-
-```
-$ fleet log view fleet-database-deadlock
-Aug 21 03:19:17 aux-d47eca0a fleet-db-deadlocks: At 2015-08-20T23:09:25 mysql.<environment>.<fleet>.f.nchr.io deadlocked on magento.catalog (index: PRIMARY, user: master): update catalog set price = 10000;
-```
-
-You can also inspect the most recent deadlocks in an environment
-(subject to the limits on MySQL's retention of this information):
-
-```
-$ fleet database deadlocks <environment>
-ts	server	db	tbl	idx	user	hostname	txn_id	txn_time	query	victim
-2015-08-20T23:09:25	mysql.<environment>.<fleet>.f.nchr.io	test innodb_deadlock_maker	PRIMARY	master		0	24	UPDATE catalog SET price = 10000; 0
-```
-
-Once it has occurred a deadlock will continue to be reported until
-another deadlock becomes the new "latest deadlock". The logging
-mechanism described above will automatically use this mechanism to
-ensure each deadlock is logged once. If you would like to clear a
-deadlock manually you can use the `--clear` argument:
-
-```
-$ fleet database deadlocks <environment>
-ts	server	db	tbl	idx	user	hostname	txn_id	txn_time	query	victim
-2015-08-20T23:09:25	mysql.<environment>.<fleet>.f.nchr.io	test innodb_deadlock_maker	PRIMARY	master		0	24	UPDATE catalog SET price = 10000; 0
-$ fleet database deadlocks <environment>  --clear
-ts	server	db	tbl	idx	user	hostname	txn_id	txn_time	query	victim
-2015-08-20T23:09:25	mysql.<environment>.<fleet>.f.nchr.io	test innodb_deadlock_maker	PRIMARY	master		0	24	UPDATE catalog SET price = 10000; 0
-$ fleet database deadlocks <environment>
-ts	server	db	tbl	idx	user	hostname	txn_id	txn_time	query	victim
-```
+present as slow page loads or errors.
 
 Last Resort
 --------


### PR DESCRIPTION
2015-09-28 test:

```
$ fleet database deadlocks prod
usage: fleet database [-h] {connect,dump} ...
fleet database: error: invalid choice: 'deadlocks' (choose from 'connect', 'dump')
```
