### PR TITLE
Update Redis session example configuration

### DIFF
--- a/docs/configuring-magento-2-for-fleet/configure-cache-and-sessions.md
+++ b/docs/configuring-magento-2-for-fleet/configure-cache-and-sessions.md
@@ -15,7 +15,10 @@ Add the following stanza to the configuration in `env.php`. Be sure to **replace
   'session' =>
   array(
     'save' => 'redis',
-    'save_path' => 'redis-session:6379',
+    'redis' => array(
+      'host' => 'redis-session',
+      'port' => '6379',
+    ),
   ),
   'cache' =>
   array(


### PR DESCRIPTION
The configuration required for redis sessions has changed
as of Magneto version 2.0.6. This updates the configuration
sample to work with 2.0.6+
